### PR TITLE
Add basic React login page

### DIFF
--- a/ReactLogin/LoginPage.js
+++ b/ReactLogin/LoginPage.js
@@ -1,0 +1,28 @@
+function LoginPage() {
+  const [username, setUsername] = React.useState('');
+  const [password, setPassword] = React.useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    alert(`Username: ${username}\nPassword: ${password}`);
+  };
+
+  return (
+    <div style={{ maxWidth: '300px', margin: '100px auto', fontFamily: 'Arial, sans-serif' }}>
+      <h2>Login</h2>
+      <form onSubmit={handleSubmit}>
+        <div style={{ marginBottom: '10px' }}>
+          <label>Username</label><br />
+          <input type="text" value={username} onChange={e => setUsername(e.target.value)} required style={{ width: '100%' }} />
+        </div>
+        <div style={{ marginBottom: '10px' }}>
+          <label>Password</label><br />
+          <input type="password" value={password} onChange={e => setPassword(e.target.value)} required style={{ width: '100%' }} />
+        </div>
+        <button type="submit" style={{ width: '100%', padding: '8px' }}>Login</button>
+      </form>
+    </div>
+  );
+}
+
+ReactDOM.render(<LoginPage />, document.getElementById('root'));

--- a/ReactLogin/README.md
+++ b/ReactLogin/README.md
@@ -1,0 +1,3 @@
+# React Login Page
+
+This folder contains a simple React login page using CDN links. Open `index.html` in a browser to view it.

--- a/ReactLogin/index.html
+++ b/ReactLogin/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Login Page</title>
+  <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+  <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" src="./LoginPage.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new `ReactLogin` folder with a simple login page using React via CDN

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68566a386e94832882e0c2e989865138